### PR TITLE
Use the userAgent to identify the safari browser

### DIFF
--- a/vuebar.js
+++ b/vuebar.js
@@ -713,7 +713,7 @@
                 (ua.toLowerCase().indexOf('chrome') > -1) && (vendor.toLowerCase().indexOf('google') > -1)
             );
 
-            var safari = !!window.safari;
+            var safari = !!window.safari || ((ua.toLowerCase().indexOf('safari') > -1) && (vendor.toLowerCase().indexOf('apple') > -1));
 
             var ie8 = getIEVersion() == 8;
             var ie9 = getIEVersion() == 9;


### PR DESCRIPTION
In some cases, such as electron html5 hybrid applications, Apple's application within the webkit engine to limit certain functions such as window.safari