### PR TITLE
Don't prevent parent scroll when vuebar is not shown

### DIFF
--- a/vuebar.js
+++ b/vuebar.js
@@ -290,6 +290,9 @@
 
 
         function preventParentScroll(el, event){
+            if (state.visibleArea >= 1) {
+				return false;
+			}
             var state = getState(el);
 
             var scrollDist = state.el2.scrollHeight - state.el2.clientHeight;

--- a/vuebar.js
+++ b/vuebar.js
@@ -290,10 +290,10 @@
 
 
         function preventParentScroll(el, event){
+            var state = getState(el);
             if (state.visibleArea >= 1) {
 				return false;
 			}
-            var state = getState(el);
 
             var scrollDist = state.el2.scrollHeight - state.el2.clientHeight;
             var scrollTop = state.el2.scrollTop;


### PR DESCRIPTION
If the vuebar is not shown, ie the content fits into it's container, and preventParentScroll is set to true, the parent should not be prevented from scrolling. 

Intended behaviour:
-vuebar shown, preventParentScroll = true - Parent is inhibited from scrolling.
-vuebar shown, preventParentScroll = false - Parent is not inhibited from scrolling.
-vuebar hidden, preventParentScroll = true - Parent is not inhibited from scrolling.
-vuebar hidden, preventParentScroll = false - Parent is not inhibited from scrolling.