### PR TITLE
Change to getNativeScrollbarWidth (fixes issue #42)

### DIFF
--- a/vuebar.js
+++ b/vuebar.js
@@ -849,6 +849,7 @@
             container.appendChild(wrapper);
 
             fullWidth = child.offsetWidth;
+            child.style.width = '100%';
             wrapper.style.overflowY = 'scroll';
             barWidth = fullWidth - child.offsetWidth;
 


### PR DESCRIPTION
Turns out the native scrollbar width calculation fails in Safari 11 (tested with 11.0.2). As the child element's `offsetWidth` still returns `100px` after setting wrapper's `overflowY` to `scroll`, the returned scrollbar width is `0`. Setting child's width to `100%` makes the browser report the correct offsetWidth, though.

Fixes: https://github.com/DominikSerafin/vuebar/issues/42